### PR TITLE
Fix for regression introduced in commit 7302245

### DIFF
--- a/src/jomlib/makefile.cpp
+++ b/src/jomlib/makefile.cpp
@@ -114,6 +114,7 @@ void Command::evaluateModifiers()
 DescriptionBlock::DescriptionBlock(Makefile* mkfile)
 :   m_bFileExists(false),
     m_bVisitedByCycleCheck(false),
+    m_bVisitedByPreselectInferenceRules(false),
     m_bNoCyclesRootedHere(false),
     m_canAddCommands(ACSUnknown),
     m_pMakefile(mkfile)

--- a/src/jomlib/makefile.h
+++ b/src/jomlib/makefile.h
@@ -104,6 +104,7 @@ public:
     bool m_bFileExists;
     bool m_bVisitedByCycleCheck;
     bool m_bNoCyclesRootedHere;
+    bool m_bVisitedByPreselectInferenceRules;
     QVector<InferenceRule*> m_inferenceRules;
 
     enum AddCommandsState { ACSUnknown, ACSEnabled, ACSDisabled };

--- a/src/jomlib/parser.cpp
+++ b/src/jomlib/parser.cpp
@@ -726,16 +726,17 @@ QVector<InferenceRule*> Parser::findRulesByTargetName(const QString& targetFileP
 
 void Parser::preselectInferenceRules(DescriptionBlock *target)
 {
-    if (!target->m_commands.isEmpty()) {
-        /* If we already have commands for this target, then we've already
-         * generated all the commands for the dependents already. Nothing
-         * more to do. */
+    if (target->m_bVisitedByPreselectInferenceRules)
+        // We already processed this target
         return;
-    }
 
-    QVector<InferenceRule *> rules = findRulesByTargetName(target->targetName());
-    if (!rules.isEmpty())
-        target->m_inferenceRules = rules;
+    target->m_bVisitedByPreselectInferenceRules = true;
+
+    if (target->m_commands.isEmpty()) {
+        QVector<InferenceRule*> rules = findRulesByTargetName(target->targetName());
+        if (!rules.isEmpty())
+            target->m_inferenceRules = rules;
+    }
 
     foreach (const QString &dependentName, target->m_dependents) {
         DescriptionBlock *dependent = m_makefile->target(dependentName);


### PR DESCRIPTION
Entire subtrees of dependencies were skipped in preselectInferenceRules leading to incorrect build order of dependencies. The assumption that if a target has commands, than no further processing of its dependencies is necessary is incorrect. In our specific case, this led to linking of dll starting before any of the object files were built for the dll.

Fixed the original performance problem with an extra flag instead, that marks whether a target (and its dependency subtree) has already been visited. preselectInferenceRules still completes instantly for a large project, and build order is correct.